### PR TITLE
fix for temp/hum sensor type v1

### DIFF
--- a/aqara.coffee
+++ b/aqara.coffee
@@ -404,7 +404,7 @@ module.exports = (env) ->
       @name = @config.name
       @_state = lastState?.state?.value
       @_battery = lastState?.battery?.value
-      
+
       @attributes = {}
 
       @attributes.battery = {
@@ -476,7 +476,7 @@ module.exports = (env) ->
       if @config.pressure
         @_pressure = lastState?.pressure?.value
       @_battery = lastState?.battery?.value
-      
+
       @attributes = {}
 
       @attributes.battery = {
@@ -546,12 +546,12 @@ module.exports = (env) ->
       )
 
       # Listen for device reports
-      @board.on("sensor", @reportHandler)
+      @board.on("report", @reportHandler)
 
       super()
 
     destroy: ->
-      @board.removeListener "sensor", @reportHandler
+      @board.removeListener "report", @reportHandler
       super()
 
     getTemperature: -> Promise.resolve @_temperature

--- a/lumi-aqara/lib/subdevice.js
+++ b/lumi-aqara/lib/subdevice.js
@@ -68,19 +68,16 @@ var Subdevice = function (_events$EventEmitter) {
 
             // Get temperature
             if (typeof data.temperature !== 'undefined') this._temperature = data.temperature / 100;
-            else {
-              this._temperature = data._temperature; // This is for v1 sensors
-            }
+            if (typeof data._temperature !== 'undefined') this._temperature = data._temperature; // This is for v1 sensors
+
             // Get humidity
             if (typeof data.humidity !== 'undefined') this._humidity = data.humidity / 100;
-            else {
-              this._humidity = data._humidity; // This is for v1 sensors
-            }
+            if (typeof data._humidity !== 'undefined') this._humidity = data._humidity; // This is for v1 sensors
+
             // Get pressure
             if (typeof data.pressure !== 'undefined') this._pressure = data.pressure / 100;
-            else {
-              this._pressure = data._pressure; // This is for v1 sensors
-            }
+            if (typeof data._pressure !== 'undefined') this._pressure = data._pressure; // This is for v1 sensors
+
 
             // If receiving a status
             if (typeof data.status !== 'undefined' && data.status !== 'iam'){

--- a/lumi-aqara/lib/subdevice.js
+++ b/lumi-aqara/lib/subdevice.js
@@ -68,12 +68,19 @@ var Subdevice = function (_events$EventEmitter) {
 
             // Get temperature
             if (typeof data.temperature !== 'undefined') this._temperature = data.temperature / 100;
-
-            // Get pressure
+            else {
+              this._temperature = data._temperature; // This is for v1 sensors
+            }
+            // Get humidity
             if (typeof data.humidity !== 'undefined') this._humidity = data.humidity / 100;
-
+            else {
+              this._humidity = data._humidity; // This is for v1 sensors
+            }
             // Get pressure
             if (typeof data.pressure !== 'undefined') this._pressure = data.pressure / 100;
+            else {
+              this._pressure = data._pressure; // This is for v1 sensors
+            }
 
             // If receiving a status
             if (typeof data.status !== 'undefined' && data.status !== 'iam'){


### PR DESCRIPTION
This fixes the temp/hum sensor type v1. This sensor has a different subdevice array:

20:33:19.962 [pimatic-aqara] info: Subdevice {
20:33:19.962 [pimatic-aqara] info:>  domain: null,
20:33:19.962 [pimatic-aqara] info:>  _events: { report: [Function] },
20:33:19.962 [pimatic-aqara] info:>  _eventsCount: 1,
20:33:19.962 [pimatic-aqara] info:>  _maxListeners: undefined,
20:33:19.962 [pimatic-aqara] info:>  _sid: '158d0001dcc362',
20:33:19.962 [pimatic-aqara] info:>  _type: 'temperature',
20:33:19.962 [pimatic-aqara] info:>  _voltage: 2975,
20:33:19.962 [pimatic-aqara] info:>  _state: null,
20:33:19.962 [pimatic-aqara] info:>  _action: false,
20:33:19.962 [pimatic-aqara] info:>  _temperature: 22.05,
20:33:19.962 [pimatic-aqara] info:>  _pressure: undefined,
20:33:19.962 [pimatic-aqara] info:>  _humidity: undefined }
