### PR TITLE
Fix for multiple ips on interface

### DIFF
--- a/lumi-aqara/index.js
+++ b/lumi-aqara/index.js
@@ -40,11 +40,17 @@ var Aqara = function (_events$EventEmitter) {
         var _iteratorError = undefined;
 
         try {
+          var i = 0;
           for (var _iterator = networkIface[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-            var connection = _step.value;
 
+            var connection = _step.value;
             if (connection.family === 'IPv4') {
-              _this._serverSocket.addMembership(MULTICAST_ADDRESS, connection.address);
+              console.log(MULTICAST_ADDRESS)
+              console.log(connection)
+              if(i == 0){
+                _this._serverSocket.addMembership(MULTICAST_ADDRESS, connection.address);
+                i++;
+              }
             }
           }
         } catch (err) {

--- a/lumi-aqara/index.js
+++ b/lumi-aqara/index.js
@@ -42,11 +42,8 @@ var Aqara = function (_events$EventEmitter) {
         try {
           var i = 0;
           for (var _iterator = networkIface[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-
             var connection = _step.value;
             if (connection.family === 'IPv4') {
-              console.log(MULTICAST_ADDRESS)
-              console.log(connection)
               if(i == 0){
                 _this._serverSocket.addMembership(MULTICAST_ADDRESS, connection.address);
                 i++;


### PR DESCRIPTION
This is a messy fix if the host has multiple ip adresses or aliases asigned. 

This is the error message you'll get:
```
16:49:24.974 [pimatic] error: An uncaught exception occurred: Error: addMembership EADDRINUSE
16:49:24.974 [pimatic] error:>    at exports._errnoException (util.js:907:11)
16:49:24.974 [pimatic] error:>    at Socket.addMembership (dgram.js:464:11)
16:49:24.974 [pimatic] error:>    at Socket.<anonymous> (/home/kris/pimatic-app/node_modules/pimatic-aqara/lumi-aqara/index.js:50:35)
16:49:24.974 [pimatic] error:>    at emitNone (events.js:67:13)
16:49:24.974 [pimatic] error:>    at Socket.emit (events.js:166:7)
16:49:24.974 [pimatic] error:>    at startListening (dgram.js:121:10)
16:49:24.974 [pimatic] error:>    at dgram.js:221:7
16:49:24.974 [pimatic] error:>    at nextTickCallbackWith3Args (node.js:522:9)
16:49:24.974 [pimatic] error:>    at process._tickCallback (node.js:428:17)
16:49:24.974 [pimatic] error:> This is most probably a bug in pimatic or in a module, please report it!
```